### PR TITLE
Require Go 1.18 as a minimum

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.17'
           - '1.18'
+          - '1.19'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.2.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,3 +23,5 @@ checksum:
   name_template: 'checksums.txt'
 release:
   prerelease: auto
+changelog:
+  use: github-native

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/bodgit/rvz/badge.svg?branch=master)](https://coveralls.io/github/bodgit/rvz?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/bodgit/rvz)](https://goreportcard.com/report/github.com/bodgit/rvz)
 [![GoDoc](https://godoc.org/github.com/bodgit/rvz?status.svg)](https://godoc.org/github.com/bodgit/rvz)
+![Go version](https://img.shields.io/badge/Go-1.19-brightgreen.svg)
 ![Go version](https://img.shields.io/badge/Go-1.18-brightgreen.svg)
-![Go version](https://img.shields.io/badge/Go-1.17-brightgreen.svg)
 
 # Dolphin RVZ disc images
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bodgit/rvz
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bodgit/plumbing v1.2.0


### PR DESCRIPTION
Maintainer of progressbar package keeps breaking support for < 1.18 by bumping the dependencies unnecessarily so just require 1.18.